### PR TITLE
Restructuring + basic RV32I structs

### DIFF
--- a/src/RV32I/mod.rs
+++ b/src/RV32I/mod.rs
@@ -1,0 +1,66 @@
+use std::{fs::File, io::{Read, Result}};
+
+pub struct CPU {
+    memory: RAM,
+    running: bool,
+    xreg: [u32; 32],
+    pc: u32,
+    dec_inst: Option<Instruction>,
+}
+
+impl CPU {
+    pub fn new() -> Self {
+        Self { memory: RAM::new(), running: true, xreg: [0; 32], pc: 0, dec_inst: None }
+    }
+
+    pub fn run(&mut self) {
+        while self.running {
+            self.fetch();
+            self.decode();
+            self.execute();
+        }
+    }
+
+    fn fetch(&mut self) {
+        todo!()
+    }
+
+    fn decode(&mut self) {
+        todo!()
+    }
+
+    fn execute(&mut self) {
+        todo!()
+    }
+}
+
+pub struct RAM {
+    mem: Vec<u8>,
+}
+
+impl RAM {
+    pub fn new() -> Self {
+        Self { mem: vec![0; 1073741824] }
+    }
+
+    pub fn from_raw(mut raw: File) -> Result<RAM> {
+        let mut buffer: Vec<u8> = Vec::new();
+        raw.read_to_end(&mut buffer)?;
+        Ok(Self { mem: buffer })
+    }
+}
+
+struct Instruction {
+    opcode: Opcode,
+    rs1: IOReg,
+    rs2: IOReg,
+    rd: IOReg,
+}
+
+enum Opcode {}
+
+enum IOReg {
+    Ptr(u32),
+    Reg(u8),
+    None,
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,54 +1,6 @@
-use std::{error::Error, io::Read, vec::Vec};
-
-struct CPU {
-    memory: Box<RAM>,
-    running: bool,
-}
-
-impl CPU {
-    fn new() -> Self {
-        Self { memory: Box::new(RAM::new()), running: true }
-    }
-
-    fn run(&mut self) {
-        while self.running {
-            self.fetch();
-            self.decode();
-            self.execute();
-        }
-    }
-
-    fn fetch(&mut self) {
-        todo!();
-    }
-
-    fn decode(&mut self) {
-        todo!();
-    }
-
-    fn execute(&mut self) {
-        todo!();
-    }
-}
-
-struct RAM {
-    mem: Vec<u8>,
-}
-
-impl RAM {
-    fn new() -> Self {
-        Self { mem: Vec::new() }
-    }
-
-    fn new_from_raw(mut raw: std::fs::File) -> std::io::Result<RAM> {
-        let mut buffer: Vec<u8> = Vec::new();
-
-        raw.read_to_end(&mut buffer)?;
-
-        Ok(RAM { mem: buffer })
-    }
-}
+mod RV32I;
+mod RV64I;
 
 fn main() {
-    let CPU = CPU::new();
+       
 }


### PR DESCRIPTION
Restructured to allow for cleaner architecture separation (RV32I and RV64I). Also started some work on RV32I CPU & RAM structs